### PR TITLE
try rebalancing via priority queue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 gem 'resque', ['>= 1.15.0', '< 2.0']
 gem 'json' 
+gem 'priority_queue'
 
 group :development do
   gem 'shotgun'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     resque-sliders (0.2.2)
+      priority_queue (~> 0.2)
       resque (>= 1.15.0, < 2.0)
 
 GEM
@@ -10,6 +11,7 @@ GEM
     json (1.7.5)
     minitest (4.1.0)
     multi_json (1.3.6)
+    priority_queue (0.2.0)
     rack (1.4.1)
     rack-protection (1.2.0)
       rack
@@ -38,6 +40,7 @@ PLATFORMS
 DEPENDENCIES
   json
   minitest
+  priority_queue
   rake
   resque (>= 1.15.0, < 2.0)
   resque-sliders!

--- a/lib/resque-sliders/commander.rb
+++ b/lib/resque-sliders/commander.rb
@@ -31,6 +31,13 @@ module Resque
           @host_status["#{host}:current_children"].to_i if max_children(host)
         end
 
+        def host_current_worker_map
+          all_hosts.inject({}) do |hash, host|
+            hash[host] = current_children(host).to_i
+            hash
+          end
+        end
+
         # Return max children count or nil if Host hasn't registered itself.
         def max_children(host)
           max = @host_status["#{host}:max_children"].to_i

--- a/resque-sliders.gemspec
+++ b/resque-sliders.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{Resque-Sliders: a plugin for resque that controls which resque workers are running on each host, from within Resque-web}
 
   s.add_dependency 'resque', ['>= 1.15.0', '< 2.0']
+  s.add_runtime_dependency 'priority_queue', '~> 0.2'
   s.extra_rdoc_files = ["README.md", "MIT-LICENSE"]
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
This PR buys us the ability to rebalance workers for a queue based on the number of workers a host currently has, i.e. workers will be more uniformly balanced across the fleet.

Note:  This is not thread safe.  If multiple users are changing the queue counts at the same time, the balancing of the queues might be off.

@evanbattaglia @tony-bye 
